### PR TITLE
Mitigated pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: airrlines app
+name: airlines_app
 description: A flight booking app.
 
 # The following defines the version and build number for your application.


### PR DESCRIPTION
Fixed "name" field must be a valid Dart identifier.